### PR TITLE
remove duplicate/selfsame definitions, huh

### DIFF
--- a/cms/config/db_settings.conf.php
+++ b/cms/config/db_settings.conf.php
@@ -1,66 +1,37 @@
 <?php
-$db_settings['type'] =                'sqlite';
+// SQLight3:
+$db_settings['type'] = 'sqlite';
+$db_settings['db_content_file'] = 'cms/data/content.sqlite';
+$db_settings['db_entry_file'] = 'cms/data/entries.sqlite';
+$db_settings['db_userdata_file'] = 'cms/data/userdata.sqlite';
 
-$db_settings['db_content_file'] =     'cms/data/content.sqlite';
-$db_settings['settings_table'] =      'phpsqlitecms_settings';
-$db_settings['pages_table'] =         'phpsqlitecms_pages';
-$db_settings['menu_table'] =          'phpsqlitecms_menus';
-$db_settings['gcb_table'] =           'phpsqlitecms_gcb';
-$db_settings['news_table'] =          'phpsqlitecms_news';
-$db_settings['notes_table'] =         'phpsqlitecms_notes';
-$db_settings['photo_table'] =         'phpsqlitecms_photos';
-$db_settings['banlists_table'] =      'phpsqlitecms_banlists';
-
-$db_settings['db_entry_file'] =       'cms/data/entries.sqlite';
-$db_settings['comment_table'] =       'phpsqlitecms_comments';
-$db_settings['newsletter_table'] =    'phpsqlitecms_newsletter';
-
-$db_settings['db_userdata_file'] =    'cms/data/userdata.sqlite';
-$db_settings['userdata_table'] =      'phpsqlitecms_userdata';
-
-/*
-// PostgreSQL:
+/*// PostgreSQL:
 $db_settings['type'] = 'postgresql';
-
 $db_settings['host'] = 'localhost';
 $db_settings['port'] = 5432;
 $db_settings['user'] = 'user';
 $db_settings['password'] = 'password';
 $db_settings['database'] = 'phpsqlitecms';
-
-$db_settings['settings_table'] = 'phpsqlitecms_settings';
-$db_settings['pages_table'] = 'phpsqlitecms_pages';
-$db_settings['menu_table'] = 'phpsqlitecms_menus';
-$db_settings['gcb_table'] = 'phpsqlitecms_gcb';
-$db_settings['news_table'] = 'phpsqlitecms_news';
-$db_settings['news_table'] = 'phpsqlitecms_news';
-$db_settings['notes_table'] = 'phpsqlitecms_notes';
-$db_settings['photo_table'] = 'phpsqlitecms_photos';
-$db_settings['banlists_table'] = 'phpsqlitecms_banlists';
-$db_settings['comment_table'] = 'phpsqlitecms_comments';
-$db_settings['userdata_table'] = 'phpsqlitecms_userdata';
 */
 
-/*
-// MySQL:
+/*// MySQL:
 $db_settings['type'] = 'mysql';
-
 $db_settings['host'] = 'localhost';
 $db_settings['port'] = 3306;
 $db_settings['user'] = 'root';
 $db_settings['password'] = '';
 $db_settings['database'] = 'phpsqlitecms';
+*/
 
-$db_settings['settings_table'] = 'phpsqlitecms_settings';
-$db_settings['pages_table'] = 'phpsqlitecms_pages';
-$db_settings['menu_table'] = 'phpsqlitecms_menus';
-$db_settings['gcb_table'] = 'phpsqlitecms_gcb';
-$db_settings['news_table'] = 'phpsqlitecms_news';
-$db_settings['news_table'] = 'phpsqlitecms_news';
-$db_settings['notes_table'] = 'phpsqlitecms_notes';
-$db_settings['photo_table'] = 'phpsqlitecms_photos';
 $db_settings['banlists_table'] = 'phpsqlitecms_banlists';
 $db_settings['comment_table'] = 'phpsqlitecms_comments';
+$db_settings['gcb_table'] = 'phpsqlitecms_gcb';
+$db_settings['menu_table'] = 'phpsqlitecms_menus';
+$db_settings['news_table'] = 'phpsqlitecms_news';
+$db_settings['newsletter_table'] = 'phpsqlitecms_newsletter';
+$db_settings['notes_table'] = 'phpsqlitecms_notes';
+$db_settings['pages_table'] = 'phpsqlitecms_pages';
+$db_settings['photo_table'] = 'phpsqlitecms_photos';
+$db_settings['settings_table'] = 'phpsqlitecms_settings';
 $db_settings['userdata_table'] = 'phpsqlitecms_userdata';
-*/
 ?>


### PR DESCRIPTION
just a cleanup, keep database/backend specific items at one place
and common definitions at another or at end; so that it's easy to
switch and, or change the database/backend.